### PR TITLE
Fixing file reference in main block of bower.json file.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "description": "Standalone version of Babel-Polyfill built into a single JS file.",
   "version": "7.0.0-alpha.20",
   "main": [
-	"polyfill.js"
+	"babel-polyfill.js"
   ],
   "keywords": [
     "babel",


### PR DESCRIPTION
The main block of the bower.json file should reference the relevant files in the package and your file was named babel-polyfill.js, not polyfill.js. Easy fix 😄 